### PR TITLE
Add game templates with Select2-style template selector

### DIFF
--- a/src/components/game-detail/form.ts
+++ b/src/components/game-detail/form.ts
@@ -375,9 +375,23 @@ export class GameDetailFormComponent extends BaseComponent {
       <div class="h-full overflow-hidden flex flex-col" @save-template="${this.handleSaveTemplate}">
         <form @submit="${this.handleSubmit}" class="flex-1 overflow-hidden flex flex-col gap-md">
           <div class="px-md flex-1 overflow-y-auto">
+            <!-- Game Name Field -->
+            <div class="form-group pt-md">
+              <label for="game-name" class="form-label"> Game Name </label>
+              <input
+                type="text"
+                id="game-name"
+                name="name"
+                .value="${this.gameName}"
+                @input="${this.handleGameNameInput}"
+                required
+                class="form-input"
+                placeholder="Enter game name" />
+            </div>
+
             <!-- Template Selector (create mode only, when templates exist) -->
             ${this.context === "create" && this.templates.length > 0 ? html`
-              <div class="form-group pt-md">
+              <div class="form-group">
                 <label class="form-label">Start from Template</label>
                 <div class="flex gap-2 items-center">
                   <x-template-select
@@ -397,24 +411,17 @@ export class GameDetailFormComponent extends BaseComponent {
                   ` : ''}
                 </div>
               </div>
+
+              <div class="flex items-center gap-4 my-md">
+                <div class="flex-1 border-t border-gray-300"></div>
+                <span class="text-sm font-medium text-gray-500">OR</span>
+                <div class="flex-1 border-t border-gray-300"></div>
+              </div>
             ` : ''}
 
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-md">
               <!-- Section A: Basic Fields -->
               <div class="md:col-span-1 lg:col-span-1 space-y-0">
-                <!-- Game Name Field -->
-                <div class="form-group">
-                  <label for="game-name" class="form-label"> Game Name </label>
-                  <input
-                    type="text"
-                    id="game-name"
-                    name="name"
-                    .value="${this.gameName}"
-                    @input="${this.handleGameNameInput}"
-                    required
-                    class="form-input"
-                    placeholder="Enter game name" />
-                </div>
                 <!-- Target Score Field -->
                 <div class="form-group">
                   <label for="target-score" class="form-label"> Target Score </label>

--- a/src/components/game-detail/form.ts
+++ b/src/components/game-detail/form.ts
@@ -1,9 +1,12 @@
 import { html } from "lit";
 import { consume } from "@lit/context";
 import { customElement, property, state } from "lit/decorators.js";
-import { BaseComponent } from "@/utils";
+import { createRef, ref, Ref } from "lit/directives/ref.js";
+import { BaseComponent, parseTimeLimit, type GameTemplate } from "@/utils";
 import { gameListContext, type GameListContext } from "@/context";
-import { GameStorageService, StoredGame } from "@/services";
+import { GameStorageService, StoredGame, TemplateStorageService } from "@/services";
+import type { ModalComponent } from "@/components/modal/modal.js";
+import type { SaveTemplateModalComponent } from "./save-template-modal.js";
 import barba from "@barba/core";
 
 type GameFormContext = "create" | "edit";
@@ -53,7 +56,20 @@ export class GameDetailFormComponent extends BaseComponent {
   @property({ type: String, attribute: "context" })
   context: GameFormContext = "create";
 
+  @state()
+  templates: GameTemplate[] = [];
+
+  @state()
+  selectedTemplateId: string = "";
+
+  @state()
+  templateToDelete: GameTemplate | null = null;
+
   storage = GameStorageService.getInstance();
+  templateStorage = TemplateStorageService.getInstance();
+
+  private saveTemplateModalRef: Ref<SaveTemplateModalComponent> = createRef();
+  private deleteModalRef: Ref<ModalComponent> = createRef();
 
   get isEditMode() {
     return this.context === "edit";
@@ -71,8 +87,21 @@ export class GameDetailFormComponent extends BaseComponent {
     return (this.game?.scoringHistory ?? []).length === 0;
   }
 
+  private get templateFieldsValid(): boolean {
+    const hasPlayers = this.players.length >= 1;
+    const targetScoreValid = this.targetScore === null || this.targetScore > 0;
+    const timeValid = !this.isTimedGame || (this.hours > 0 || this.minutes > 0);
+    const timerBehaviorValid = !this.isTimedGame || this.targetScore === null || this.timerBehavior !== null;
+    return hasPlayers && targetScoreValid && timeValid && timerBehaviorValid;
+  }
+
+  private get formIsValid(): boolean {
+    return this.templateFieldsValid && this.gameName.trim().length > 0;
+  }
+
   connectedCallback() {
     super.connectedCallback();
+    this.templates = this.templateStorage.getAllTemplates();
     if (this.context === "edit") {
       this.populateForm();
     }
@@ -93,9 +122,9 @@ export class GameDetailFormComponent extends BaseComponent {
         // Populate time-related fields
         if (storedGame.timeLimit) {
           this.isTimedGame = true;
-          const totalMinutes = Math.floor(storedGame.timeLimit / 60);
-          this.hours = Math.floor(totalMinutes / 60);
-          this.minutes = totalMinutes % 60;
+          const { hours, minutes } = parseTimeLimit(storedGame.timeLimit);
+          this.hours = hours;
+          this.minutes = minutes;
           this.timerBehavior = storedGame.timerBehavior;
         }
 
@@ -105,6 +134,16 @@ export class GameDetailFormComponent extends BaseComponent {
         console.warn(`No stored game found with ID: ${id}`);
       }
     }
+  }
+
+  private resetFormToDefaults() {
+    this.players = ["Player 1"];
+    this.targetScore = null;
+    this.isTimedGame = false;
+    this.hours = 0;
+    this.minutes = 0;
+    this.timerBehavior = null;
+    this.turnTrackingEnabled = true;
   }
 
   private handleSubmit(e: Event) {
@@ -182,6 +221,103 @@ export class GameDetailFormComponent extends BaseComponent {
     }
   }
 
+  private handleTemplateSelect(e: Event) {
+    const select = e.target as HTMLSelectElement;
+    this.selectedTemplateId = select.value;
+
+    if (!this.selectedTemplateId) {
+      this.resetFormToDefaults();
+      return;
+    }
+
+    const template = this.templateStorage.getTemplate(this.selectedTemplateId);
+    if (!template) return;
+
+    this.players = [...template.players];
+    this.targetScore = template.targetScore;
+    this.isTimedGame = template.timeLimit !== null && template.timeLimit > 0;
+    if (this.isTimedGame && template.timeLimit) {
+      const { hours, minutes } = parseTimeLimit(template.timeLimit);
+      this.hours = hours;
+      this.minutes = minutes;
+    } else {
+      this.hours = 0;
+      this.minutes = 0;
+    }
+    this.timerBehavior = template.timerBehavior;
+    this.turnTrackingEnabled = template.turnTrackingEnabled;
+  }
+
+  private handleDeleteTemplateClick() {
+    if (!this.selectedTemplateId) return;
+    const template = this.templateStorage.getTemplate(this.selectedTemplateId);
+    if (!template) return;
+
+    this.templateToDelete = template;
+    this.deleteModalRef.value?.open({
+      title: "Delete Template",
+      content: html`
+        <p class="mb-4">
+          Are you sure you want to delete the template "${template.templateName}"? This action cannot be undone.
+        </p>
+        <div class="flex gap-2 justify-end">
+          <button
+            type="button"
+            @click=${() => this.deleteModalRef.value?.close()}
+            class="px-4 py-2 bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors">
+            Cancel
+          </button>
+          <button
+            type="button"
+            @click=${() => this.confirmDeleteTemplate()}
+            class="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors">
+            Delete
+          </button>
+        </div>
+      `,
+      size: "sm",
+      onClose: () => {
+        this.templateToDelete = null;
+      },
+    });
+  }
+
+  private confirmDeleteTemplate() {
+    if (!this.templateToDelete) return;
+    this.templateStorage.deleteTemplate(this.templateToDelete.id);
+    this.templateToDelete = null;
+    this.selectedTemplateId = "";
+    this.resetFormToDefaults();
+    this.templates = this.templateStorage.getAllTemplates();
+    this.deleteModalRef.value?.close();
+  }
+
+  private handleOpenSaveTemplateModal() {
+    this.saveTemplateModalRef.value?.open();
+  }
+
+  private handleSaveTemplate(e: CustomEvent) {
+    const { templateName } = e.detail;
+    const timeLimit = this.isTimedGame ? (this.hours * 3600) + (this.minutes * 60) : null;
+    const timerBehavior = this.isTimedGame && this.targetScore !== null ? this.timerBehavior : null;
+
+    const template = this.templateStorage.createTemplate({
+      templateName,
+      players: this.players,
+      targetScore: this.targetScore,
+      timeLimit,
+      timerBehavior,
+      turnTrackingEnabled: this.turnTrackingEnabled,
+    });
+
+    if (template) {
+      this.templates = this.templateStorage.getAllTemplates();
+      this.saveTemplateModalRef.value?.close();
+    } else {
+      this.saveTemplateModalRef.value?.showSaveError();
+    }
+  }
+
   private handlePlayersChanged(e: CustomEvent) {
     this.players = e.detail.players;
   }
@@ -235,60 +371,185 @@ export class GameDetailFormComponent extends BaseComponent {
     barba.go(url.toString());
   }
 
-  private get formIsValid(): boolean {
-    const hasPlayers = this.players.length >= 1;
-    const hasName = this.gameName.trim().length > 0;
-    const targetScoreValid = this.targetScore === null || this.targetScore > 0;
-    const timeValid = !this.isTimedGame || (this.hours > 0 || this.minutes > 0);
-    const timerBehaviorValid = !this.isTimedGame || this.targetScore === null || this.timerBehavior !== null;
-
-    return hasPlayers && hasName && targetScoreValid && timeValid && timerBehaviorValid;
-  }
-
   render() {
     return html`
-      <form @submit="${this.handleSubmit}" class="h-full overflow-hidden flex flex-col gap-md">
-        <div class="px-md flex-1 overflow-y-auto">
-          <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-md">
-            <!-- Section A: Basic Fields -->
-            <div class="md:col-span-1 lg:col-span-1 space-y-0">
-              <!-- Game Name Field -->
-              <div class="form-group">
-                <label for="game-name" class="form-label"> Game Name </label>
-                <input
-                  type="text"
-                  id="game-name"
-                  name="name"
-                  .value="${this.gameName}"
-                  @input="${this.handleGameNameInput}"
-                  required
-                  class="form-input"
-                  placeholder="Enter game name" />
+      <div class="h-full overflow-hidden flex flex-col" @save-template="${this.handleSaveTemplate}">
+        <form @submit="${this.handleSubmit}" class="flex-1 overflow-hidden flex flex-col gap-md">
+          <div class="px-md flex-1 overflow-y-auto">
+            <!-- Template Selector (create mode only, when templates exist) -->
+            ${this.context === "create" && this.templates.length > 0 ? html`
+              <div class="form-group pt-md">
+                <label for="template-select" class="form-label">Start from Template</label>
+                <div class="flex gap-2 items-center">
+                  <select
+                    id="template-select"
+                    class="form-input flex-1"
+                    .value=${this.selectedTemplateId}
+                    @change="${this.handleTemplateSelect}">
+                    <option value="">-- No Template --</option>
+                    ${this.templates.map((t) => html`
+                      <option value="${t.id}">${t.templateName}</option>
+                    `)}
+                  </select>
+                  ${this.selectedTemplateId ? html`
+                    <button
+                      type="button"
+                      @click="${this.handleDeleteTemplateClick}"
+                      class="btn btn-error"
+                      title="Delete template">
+                      Delete
+                    </button>
+                  ` : ''}
+                </div>
               </div>
-              <!-- Target Score Field -->
-              <div class="form-group">
-                <label for="target-score" class="form-label"> Target Score </label>
-                <input
-                  type="number"
-                  id="target-score"
-                  name="targetScore"
-                  min="1"
-                  step="1"
-                  class="form-input"
-                  placeholder="e.g. 500"
-                  .value=${this.targetScore !== null ? String(this.targetScore) : ""}
-                  @input="${this.handleTargetScoreInput}" />
-                <p class="form-help-text">Optional - leave blank for open-ended games</p>
+            ` : ''}
+
+            <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-md">
+              <!-- Section A: Basic Fields -->
+              <div class="md:col-span-1 lg:col-span-1 space-y-0">
+                <!-- Game Name Field -->
+                <div class="form-group">
+                  <label for="game-name" class="form-label"> Game Name </label>
+                  <input
+                    type="text"
+                    id="game-name"
+                    name="name"
+                    .value="${this.gameName}"
+                    @input="${this.handleGameNameInput}"
+                    required
+                    class="form-input"
+                    placeholder="Enter game name" />
+                </div>
+                <!-- Target Score Field -->
+                <div class="form-group">
+                  <label for="target-score" class="form-label"> Target Score </label>
+                  <input
+                    type="number"
+                    id="target-score"
+                    name="targetScore"
+                    min="1"
+                    step="1"
+                    class="form-input"
+                    placeholder="e.g. 500"
+                    .value=${this.targetScore !== null ? String(this.targetScore) : ""}
+                    @input="${this.handleTargetScoreInput}" />
+                  <p class="form-help-text">Optional - leave blank for open-ended games</p>
+                </div>
+
+                <!-- Section B fields for medium screens only -->
+                <div class="md:block lg:hidden">
+                  <!-- Turn Tracking Field -->
+                  <div class="form-group">
+                    <label class="flex items-center gap-2 ${this.canChangeTurnTracking ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
+                      <input
+                        type="checkbox"
+                        id="turn-tracking"
+                        name="turnTracking"
+                        .checked=${this.turnTrackingEnabled}
+                        ?disabled=${!this.canChangeTurnTracking}
+                        @change="${this.handleTurnTrackingToggle}"
+                        class="w-4 h-4" />
+                      <span class="form-label mb-0">Turn-based Scoring</span>
+                    </label>
+                    <p class="form-help-text">Players take turns scoring in order</p>
+                    ${!this.canChangeTurnTracking ? html`
+                      <p class="form-help-text text-orange-600">Turn tracking cannot be changed after scoring begins</p>
+                    ` : ''}
+                  </div>
+                  <!-- Timed Game Field -->
+                  <div class="form-group">
+                    <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
+                      <input
+                        type="checkbox"
+                        id="timed-game"
+                        name="timedGame"
+                        .checked=${this.isTimedGame}
+                        ?disabled=${!this.canChangeTimeSettings}
+                        @change="${this.handleTimedGameToggle}"
+                        class="w-4 h-4" />
+                      <span class="form-label mb-0">Timed Game</span>
+                    </label>
+                    ${!this.canChangeTimeSettings ? html`
+                      <p class="form-help-text text-orange-600">Timer settings cannot be changed after scoring begins</p>
+                    ` : ''}
+                  </div>
+                  ${this.isTimedGame ? html`
+                    <!-- Time Limit Fields -->
+                    <div class="form-group">
+                      <label class="form-label">Time Limit</label>
+                      <div class="flex gap-2">
+                        <div class="flex-1">
+                          <input
+                            type="number"
+                            id="hours"
+                            name="hours"
+                            min="0"
+                            step="1"
+                            class="form-input"
+                            placeholder="Hours"
+                            ?disabled=${!this.canChangeTimeSettings}
+                            .value=${this.hours > 0 ? String(this.hours) : ""}
+                            @input="${this.handleHoursInput}" />
+                        </div>
+                        <div class="flex-1">
+                          <input
+                            type="number"
+                            id="minutes"
+                            name="minutes"
+                            min="0"
+                            max="59"
+                            step="1"
+                            class="form-input"
+                            placeholder="Minutes"
+                            ?disabled=${!this.canChangeTimeSettings}
+                            .value=${this.minutes > 0 ? String(this.minutes) : ""}
+                            @input="${this.handleMinutesInput}" />
+                        </div>
+                      </div>
+                      <p class="form-help-text">Enter at least 1 minute</p>
+                    </div>
+                    ${this.targetScore !== null ? html`
+                      <!-- Timer Behavior Field -->
+                      <div class="form-group">
+                        <label class="form-label">If time expires with no winner</label>
+                        <div class="flex flex-col gap-2">
+                          <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
+                            <input
+                              type="radio"
+                              name="timerBehavior"
+                              value="highest-score"
+                              .checked=${this.timerBehavior === 'highest-score'}
+                              ?disabled=${!this.canChangeTimeSettings}
+                              @change="${this.handleTimerBehaviorChange}"
+                              class="w-4 h-4" />
+                            <span>Highest Score Wins</span>
+                          </label>
+                          <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
+                            <input
+                              type="radio"
+                              name="timerBehavior"
+                              value="no-winner"
+                              .checked=${this.timerBehavior === 'no-winner'}
+                              ?disabled=${!this.canChangeTimeSettings}
+                              @change="${this.handleTimerBehaviorChange}"
+                              class="w-4 h-4" />
+                            <span>No Winner</span>
+                          </label>
+                        </div>
+                      </div>
+                    ` : ''}
+                  ` : ''}
+                </div>
               </div>
 
-              <!-- Section B fields for medium screens only -->
-              <div class="md:block lg:hidden">
+              <!-- Section B: Checkbox & Options (large screens only) -->
+              <div class="hidden lg:block space-y-0">
                 <!-- Turn Tracking Field -->
                 <div class="form-group">
                   <label class="flex items-center gap-2 ${this.canChangeTurnTracking ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
                     <input
                       type="checkbox"
-                      id="turn-tracking"
+                      id="turn-tracking-lg"
                       name="turnTracking"
                       .checked=${this.turnTrackingEnabled}
                       ?disabled=${!this.canChangeTurnTracking}
@@ -306,7 +567,7 @@ export class GameDetailFormComponent extends BaseComponent {
                   <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
                     <input
                       type="checkbox"
-                      id="timed-game"
+                      id="timed-game-lg"
                       name="timedGame"
                       .checked=${this.isTimedGame}
                       ?disabled=${!this.canChangeTimeSettings}
@@ -326,7 +587,7 @@ export class GameDetailFormComponent extends BaseComponent {
                       <div class="flex-1">
                         <input
                           type="number"
-                          id="hours"
+                          id="hours-lg"
                           name="hours"
                           min="0"
                           step="1"
@@ -339,7 +600,7 @@ export class GameDetailFormComponent extends BaseComponent {
                       <div class="flex-1">
                         <input
                           type="number"
-                          id="minutes"
+                          id="minutes-lg"
                           name="minutes"
                           min="0"
                           max="59"
@@ -385,130 +646,35 @@ export class GameDetailFormComponent extends BaseComponent {
                   ` : ''}
                 ` : ''}
               </div>
-            </div>
 
-            <!-- Section B: Checkbox & Options (large screens only) -->
-            <div class="hidden lg:block space-y-0">
-              <!-- Turn Tracking Field -->
-              <div class="form-group">
-                <label class="flex items-center gap-2 ${this.canChangeTurnTracking ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
-                  <input
-                    type="checkbox"
-                    id="turn-tracking-lg"
-                    name="turnTracking"
-                    .checked=${this.turnTrackingEnabled}
-                    ?disabled=${!this.canChangeTurnTracking}
-                    @change="${this.handleTurnTrackingToggle}"
-                    class="w-4 h-4" />
-                  <span class="form-label mb-0">Turn-based Scoring</span>
-                </label>
-                <p class="form-help-text">Players take turns scoring in order</p>
-                ${!this.canChangeTurnTracking ? html`
-                  <p class="form-help-text text-orange-600">Turn tracking cannot be changed after scoring begins</p>
-                ` : ''}
+              <!-- Section C: Player List -->
+              <div class="md:col-span-1 lg:col-span-1">
+                <x-game-detail-player-list
+                  .players="${this.players}"
+                  ?disable-editing="${!this.canChangePlayers}"
+                  @players-changed="${this.handlePlayersChanged}"></x-game-detail-player-list>
               </div>
-              <!-- Timed Game Field -->
-              <div class="form-group">
-                <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
-                  <input
-                    type="checkbox"
-                    id="timed-game-lg"
-                    name="timedGame"
-                    .checked=${this.isTimedGame}
-                    ?disabled=${!this.canChangeTimeSettings}
-                    @change="${this.handleTimedGameToggle}"
-                    class="w-4 h-4" />
-                  <span class="form-label mb-0">Timed Game</span>
-                </label>
-                ${!this.canChangeTimeSettings ? html`
-                  <p class="form-help-text text-orange-600">Timer settings cannot be changed after scoring begins</p>
-                ` : ''}
-              </div>
-              ${this.isTimedGame ? html`
-                <!-- Time Limit Fields -->
-                <div class="form-group">
-                  <label class="form-label">Time Limit</label>
-                  <div class="flex gap-2">
-                    <div class="flex-1">
-                      <input
-                        type="number"
-                        id="hours-lg"
-                        name="hours"
-                        min="0"
-                        step="1"
-                        class="form-input"
-                        placeholder="Hours"
-                        ?disabled=${!this.canChangeTimeSettings}
-                        .value=${this.hours > 0 ? String(this.hours) : ""}
-                        @input="${this.handleHoursInput}" />
-                    </div>
-                    <div class="flex-1">
-                      <input
-                        type="number"
-                        id="minutes-lg"
-                        name="minutes"
-                        min="0"
-                        max="59"
-                        step="1"
-                        class="form-input"
-                        placeholder="Minutes"
-                        ?disabled=${!this.canChangeTimeSettings}
-                        .value=${this.minutes > 0 ? String(this.minutes) : ""}
-                        @input="${this.handleMinutesInput}" />
-                    </div>
-                  </div>
-                  <p class="form-help-text">Enter at least 1 minute</p>
-                </div>
-                ${this.targetScore !== null ? html`
-                  <!-- Timer Behavior Field -->
-                  <div class="form-group">
-                    <label class="form-label">If time expires with no winner</label>
-                    <div class="flex flex-col gap-2">
-                      <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
-                        <input
-                          type="radio"
-                          name="timerBehavior"
-                          value="highest-score"
-                          .checked=${this.timerBehavior === 'highest-score'}
-                          ?disabled=${!this.canChangeTimeSettings}
-                          @change="${this.handleTimerBehaviorChange}"
-                          class="w-4 h-4" />
-                        <span>Highest Score Wins</span>
-                      </label>
-                      <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
-                        <input
-                          type="radio"
-                          name="timerBehavior"
-                          value="no-winner"
-                          .checked=${this.timerBehavior === 'no-winner'}
-                          ?disabled=${!this.canChangeTimeSettings}
-                          @change="${this.handleTimerBehaviorChange}"
-                          class="w-4 h-4" />
-                        <span>No Winner</span>
-                      </label>
-                    </div>
-                  </div>
-                ` : ''}
-              ` : ''}
-            </div>
-
-            <!-- Section C: Player List -->
-            <div class="md:col-span-1 lg:col-span-1">
-              <x-game-detail-player-list
-                .players="${this.players}"
-                ?disable-editing="${!this.canChangePlayers}"
-                @players-changed="${this.handlePlayersChanged}"></x-game-detail-player-list>
             </div>
           </div>
-        </div>
 
-        <!-- Submit Button -->
-        <div class="p-md mt-auto border-t md:flex md:justify-end">
-          <button ?disabled="${!this.formIsValid}" type="submit" class="w-full md:w-auto btn btn-primary">
-            ${this.isEditMode ? "Update Game" : "Create Game"}
-          </button>
-        </div>
-      </form>
+          <!-- Footer -->
+          <div class="p-md mt-auto border-t flex flex-col gap-2 md:flex-row md:justify-end">
+            <button
+              type="button"
+              ?disabled="${!this.templateFieldsValid}"
+              @click="${this.handleOpenSaveTemplateModal}"
+              class="w-full md:w-auto btn btn-secondary">
+              Save As Template
+            </button>
+            <button ?disabled="${!this.formIsValid}" type="submit" class="w-full md:w-auto btn btn-primary">
+              ${this.isEditMode ? "Update Game" : "Create Game"}
+            </button>
+          </div>
+        </form>
+
+        <x-save-template-modal ${ref(this.saveTemplateModalRef)}></x-save-template-modal>
+        <x-modal ${ref(this.deleteModalRef)}></x-modal>
+      </div>
     `;
   }
 }

--- a/src/components/game-detail/form.ts
+++ b/src/components/game-detail/form.ts
@@ -47,11 +47,11 @@ export class GameDetailFormComponent extends BaseComponent {
 
   @property({ type: String })
   @state()
-  timerBehavior: 'no-winner' | 'highest-score' | null = null;
+  timerBehavior: "no-winner" | "highest-score" | null = null;
 
   @property({ type: Boolean })
   @state()
-  turnTrackingEnabled: boolean = true;
+  turnTrackingEnabled: boolean = false;
 
   @property({ type: String, attribute: "context" })
   context: GameFormContext = "create";
@@ -90,8 +90,9 @@ export class GameDetailFormComponent extends BaseComponent {
   private get templateFieldsValid(): boolean {
     const hasPlayers = this.players.length >= 1;
     const targetScoreValid = this.targetScore === null || this.targetScore > 0;
-    const timeValid = !this.isTimedGame || (this.hours > 0 || this.minutes > 0);
-    const timerBehaviorValid = !this.isTimedGame || this.targetScore === null || this.timerBehavior !== null;
+    const timeValid = !this.isTimedGame || this.hours > 0 || this.minutes > 0;
+    const timerBehaviorValid =
+      !this.isTimedGame || this.targetScore === null || this.timerBehavior !== null;
     return hasPlayers && targetScoreValid && timeValid && timerBehaviorValid;
   }
 
@@ -143,7 +144,7 @@ export class GameDetailFormComponent extends BaseComponent {
     this.hours = 0;
     this.minutes = 0;
     this.timerBehavior = null;
-    this.turnTrackingEnabled = true;
+    this.turnTrackingEnabled = false;
   }
 
   private handleSubmit(e: Event) {
@@ -164,12 +165,8 @@ export class GameDetailFormComponent extends BaseComponent {
   }
 
   private handleCreateSubmit() {
-    const timeLimit = this.isTimedGame
-      ? (this.hours * 3600) + (this.minutes * 60)
-      : null;
-    const timerBehavior = this.isTimedGame && this.targetScore !== null
-      ? this.timerBehavior
-      : null;
+    const timeLimit = this.isTimedGame ? this.hours * 3600 + this.minutes * 60 : null;
+    const timerBehavior = this.isTimedGame && this.targetScore !== null ? this.timerBehavior : null;
 
     const game = this.storage.createGame(
       this.gameName,
@@ -190,12 +187,9 @@ export class GameDetailFormComponent extends BaseComponent {
       const existingGame = this.storage.getStoredGame(id);
 
       if (existingGame) {
-        const timeLimit = this.isTimedGame
-          ? (this.hours * 3600) + (this.minutes * 60)
-          : null;
-        const timerBehavior = this.isTimedGame && this.targetScore !== null
-          ? this.timerBehavior
-          : null;
+        const timeLimit = this.isTimedGame ? this.hours * 3600 + this.minutes * 60 : null;
+        const timerBehavior =
+          this.isTimedGame && this.targetScore !== null ? this.timerBehavior : null;
 
         const updatedGame = {
           ...existingGame,
@@ -257,7 +251,8 @@ export class GameDetailFormComponent extends BaseComponent {
       title: "Delete Template",
       content: html`
         <p class="mb-4">
-          Are you sure you want to delete the template "${template.templateName}"? This action cannot be undone.
+          Are you sure you want to delete the template "${template.templateName}"? This action
+          cannot be undone.
         </p>
         <div class="flex gap-2 justify-end">
           <button
@@ -297,7 +292,7 @@ export class GameDetailFormComponent extends BaseComponent {
 
   private handleSaveTemplate(e: CustomEvent) {
     const { templateName } = e.detail;
-    const timeLimit = this.isTimedGame ? (this.hours * 3600) + (this.minutes * 60) : null;
+    const timeLimit = this.isTimedGame ? this.hours * 3600 + this.minutes * 60 : null;
     const timerBehavior = this.isTimedGame && this.targetScore !== null ? this.timerBehavior : null;
 
     const template = this.templateStorage.createTemplate({
@@ -340,7 +335,7 @@ export class GameDetailFormComponent extends BaseComponent {
       this.timerBehavior = null;
     } else if (this.targetScore !== null && this.timerBehavior === null) {
       // Default to 'highest-score' when enabling timed game with target score
-      this.timerBehavior = 'highest-score';
+      this.timerBehavior = "highest-score";
     }
   }
 
@@ -356,7 +351,7 @@ export class GameDetailFormComponent extends BaseComponent {
 
   private handleTimerBehaviorChange(e: Event) {
     const input = e.target as HTMLInputElement;
-    this.timerBehavior = input.value as 'no-winner' | 'highest-score';
+    this.timerBehavior = input.value as "no-winner" | "highest-score";
   }
 
   private handleTurnTrackingToggle(e: Event) {
@@ -390,34 +385,38 @@ export class GameDetailFormComponent extends BaseComponent {
             </div>
 
             <!-- Template Selector (create mode only, when templates exist) -->
-            ${this.context === "create" && this.templates.length > 0 ? html`
-              <div class="form-group">
-                <label class="form-label">Start from Template</label>
-                <div class="flex gap-2 items-center">
-                  <x-template-select
-                    class="flex-1"
-                    .templates=${this.templates}
-                    .selectedTemplateId=${this.selectedTemplateId}
-                    @template-select=${this.handleTemplateSelect}>
-                  </x-template-select>
-                  ${this.selectedTemplateId ? html`
-                    <button
-                      type="button"
-                      @click="${this.handleDeleteTemplateClick}"
-                      class="btn btn-error"
-                      title="Delete template">
-                      Delete
-                    </button>
-                  ` : ''}
-                </div>
-              </div>
+            ${this.context === "create" && this.templates.length > 0
+              ? html`
+                  <div class="form-group">
+                    <label class="form-label">Start from Template</label>
+                    <div class="flex gap-2 items-center">
+                      <x-template-select
+                        class="flex-1"
+                        .templates=${this.templates}
+                        .selectedTemplateId=${this.selectedTemplateId}
+                        @template-select=${this.handleTemplateSelect}>
+                      </x-template-select>
+                      ${this.selectedTemplateId
+                        ? html`
+                            <button
+                              type="button"
+                              @click="${this.handleDeleteTemplateClick}"
+                              class="btn btn-error"
+                              title="Delete template">
+                              Delete
+                            </button>
+                          `
+                        : ""}
+                    </div>
+                  </div>
 
-              <div class="flex items-center gap-4 my-md">
-                <div class="flex-1 border-t border-gray-300"></div>
-                <span class="text-sm font-medium text-gray-500">OR</span>
-                <div class="flex-1 border-t border-gray-300"></div>
-              </div>
-            ` : ''}
+                  <div class="flex items-center gap-4 my-md">
+                    <div class="flex-1 border-t border-gray-300"></div>
+                    <span class="text-sm font-medium text-gray-500">OR</span>
+                    <div class="flex-1 border-t border-gray-300"></div>
+                  </div>
+                `
+              : ""}
 
             <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-md">
               <!-- Section A: Basic Fields -->
@@ -442,7 +441,10 @@ export class GameDetailFormComponent extends BaseComponent {
                 <div class="md:block lg:hidden">
                   <!-- Turn Tracking Field -->
                   <div class="form-group">
-                    <label class="flex items-center gap-2 ${this.canChangeTurnTracking ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
+                    <label
+                      class="flex items-center gap-2 ${this.canChangeTurnTracking
+                        ? "cursor-pointer"
+                        : "cursor-not-allowed opacity-50"}">
                       <input
                         type="checkbox"
                         id="turn-tracking"
@@ -454,13 +456,20 @@ export class GameDetailFormComponent extends BaseComponent {
                       <span class="form-label mb-0">Turn-based Scoring</span>
                     </label>
                     <p class="form-help-text">Players take turns scoring in order</p>
-                    ${!this.canChangeTurnTracking ? html`
-                      <p class="form-help-text text-orange-600">Turn tracking cannot be changed after scoring begins</p>
-                    ` : ''}
+                    ${!this.canChangeTurnTracking
+                      ? html`
+                          <p class="form-help-text text-orange-600">
+                            Turn tracking cannot be changed after scoring begins
+                          </p>
+                        `
+                      : ""}
                   </div>
                   <!-- Timed Game Field -->
                   <div class="form-group">
-                    <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
+                    <label
+                      class="flex items-center gap-2 ${this.canChangeTimeSettings
+                        ? "cursor-pointer"
+                        : "cursor-not-allowed opacity-50"}">
                       <input
                         type="checkbox"
                         id="timed-game"
@@ -471,76 +480,90 @@ export class GameDetailFormComponent extends BaseComponent {
                         class="w-4 h-4" />
                       <span class="form-label mb-0">Timed Game</span>
                     </label>
-                    ${!this.canChangeTimeSettings ? html`
-                      <p class="form-help-text text-orange-600">Timer settings cannot be changed after scoring begins</p>
-                    ` : ''}
+                    ${!this.canChangeTimeSettings
+                      ? html`
+                          <p class="form-help-text text-orange-600">
+                            Timer settings cannot be changed after scoring begins
+                          </p>
+                        `
+                      : ""}
                   </div>
-                  ${this.isTimedGame ? html`
-                    <!-- Time Limit Fields -->
-                    <div class="form-group">
-                      <label class="form-label">Time Limit</label>
-                      <div class="flex gap-2">
-                        <div class="flex-1">
-                          <input
-                            type="number"
-                            id="hours"
-                            name="hours"
-                            min="0"
-                            step="1"
-                            class="form-input"
-                            placeholder="Hours"
-                            ?disabled=${!this.canChangeTimeSettings}
-                            .value=${this.hours > 0 ? String(this.hours) : ""}
-                            @input="${this.handleHoursInput}" />
+                  ${this.isTimedGame
+                    ? html`
+                        <!-- Time Limit Fields -->
+                        <div class="form-group">
+                          <label class="form-label">Time Limit</label>
+                          <div class="flex gap-2">
+                            <div class="flex-1">
+                              <input
+                                type="number"
+                                id="hours"
+                                name="hours"
+                                min="0"
+                                step="1"
+                                class="form-input"
+                                placeholder="Hours"
+                                ?disabled=${!this.canChangeTimeSettings}
+                                .value=${this.hours > 0 ? String(this.hours) : ""}
+                                @input="${this.handleHoursInput}" />
+                            </div>
+                            <div class="flex-1">
+                              <input
+                                type="number"
+                                id="minutes"
+                                name="minutes"
+                                min="0"
+                                max="59"
+                                step="1"
+                                class="form-input"
+                                placeholder="Minutes"
+                                ?disabled=${!this.canChangeTimeSettings}
+                                .value=${this.minutes > 0 ? String(this.minutes) : ""}
+                                @input="${this.handleMinutesInput}" />
+                            </div>
+                          </div>
+                          <p class="form-help-text">Enter at least 1 minute</p>
                         </div>
-                        <div class="flex-1">
-                          <input
-                            type="number"
-                            id="minutes"
-                            name="minutes"
-                            min="0"
-                            max="59"
-                            step="1"
-                            class="form-input"
-                            placeholder="Minutes"
-                            ?disabled=${!this.canChangeTimeSettings}
-                            .value=${this.minutes > 0 ? String(this.minutes) : ""}
-                            @input="${this.handleMinutesInput}" />
-                        </div>
-                      </div>
-                      <p class="form-help-text">Enter at least 1 minute</p>
-                    </div>
-                    ${this.targetScore !== null ? html`
-                      <!-- Timer Behavior Field -->
-                      <div class="form-group">
-                        <label class="form-label">If time expires with no winner</label>
-                        <div class="flex flex-col gap-2">
-                          <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
-                            <input
-                              type="radio"
-                              name="timerBehavior"
-                              value="highest-score"
-                              .checked=${this.timerBehavior === 'highest-score'}
-                              ?disabled=${!this.canChangeTimeSettings}
-                              @change="${this.handleTimerBehaviorChange}"
-                              class="w-4 h-4" />
-                            <span>Highest Score Wins</span>
-                          </label>
-                          <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
-                            <input
-                              type="radio"
-                              name="timerBehavior"
-                              value="no-winner"
-                              .checked=${this.timerBehavior === 'no-winner'}
-                              ?disabled=${!this.canChangeTimeSettings}
-                              @change="${this.handleTimerBehaviorChange}"
-                              class="w-4 h-4" />
-                            <span>No Winner</span>
-                          </label>
-                        </div>
-                      </div>
-                    ` : ''}
-                  ` : ''}
+                        ${this.targetScore !== null
+                          ? html`
+                              <!-- Timer Behavior Field -->
+                              <div class="form-group">
+                                <label class="form-label">If time expires with no winner</label>
+                                <div class="flex flex-col gap-2">
+                                  <label
+                                    class="flex items-center gap-2 ${this.canChangeTimeSettings
+                                      ? "cursor-pointer"
+                                      : "cursor-not-allowed opacity-50"}">
+                                    <input
+                                      type="radio"
+                                      name="timerBehavior"
+                                      value="highest-score"
+                                      .checked=${this.timerBehavior === "highest-score"}
+                                      ?disabled=${!this.canChangeTimeSettings}
+                                      @change="${this.handleTimerBehaviorChange}"
+                                      class="w-4 h-4" />
+                                    <span>Highest Score Wins</span>
+                                  </label>
+                                  <label
+                                    class="flex items-center gap-2 ${this.canChangeTimeSettings
+                                      ? "cursor-pointer"
+                                      : "cursor-not-allowed opacity-50"}">
+                                    <input
+                                      type="radio"
+                                      name="timerBehavior"
+                                      value="no-winner"
+                                      .checked=${this.timerBehavior === "no-winner"}
+                                      ?disabled=${!this.canChangeTimeSettings}
+                                      @change="${this.handleTimerBehaviorChange}"
+                                      class="w-4 h-4" />
+                                    <span>No Winner</span>
+                                  </label>
+                                </div>
+                              </div>
+                            `
+                          : ""}
+                      `
+                    : ""}
                 </div>
               </div>
 
@@ -548,7 +571,10 @@ export class GameDetailFormComponent extends BaseComponent {
               <div class="hidden lg:block space-y-0">
                 <!-- Turn Tracking Field -->
                 <div class="form-group">
-                  <label class="flex items-center gap-2 ${this.canChangeTurnTracking ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
+                  <label
+                    class="flex items-center gap-2 ${this.canChangeTurnTracking
+                      ? "cursor-pointer"
+                      : "cursor-not-allowed opacity-50"}">
                     <input
                       type="checkbox"
                       id="turn-tracking-lg"
@@ -560,13 +586,20 @@ export class GameDetailFormComponent extends BaseComponent {
                     <span class="form-label mb-0">Turn-based Scoring</span>
                   </label>
                   <p class="form-help-text">Players take turns scoring in order</p>
-                  ${!this.canChangeTurnTracking ? html`
-                    <p class="form-help-text text-orange-600">Turn tracking cannot be changed after scoring begins</p>
-                  ` : ''}
+                  ${!this.canChangeTurnTracking
+                    ? html`
+                        <p class="form-help-text text-orange-600">
+                          Turn tracking cannot be changed after scoring begins
+                        </p>
+                      `
+                    : ""}
                 </div>
                 <!-- Timed Game Field -->
                 <div class="form-group">
-                  <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
+                  <label
+                    class="flex items-center gap-2 ${this.canChangeTimeSettings
+                      ? "cursor-pointer"
+                      : "cursor-not-allowed opacity-50"}">
                     <input
                       type="checkbox"
                       id="timed-game-lg"
@@ -577,76 +610,90 @@ export class GameDetailFormComponent extends BaseComponent {
                       class="w-4 h-4" />
                     <span class="form-label mb-0">Timed Game</span>
                   </label>
-                  ${!this.canChangeTimeSettings ? html`
-                    <p class="form-help-text text-orange-600">Timer settings cannot be changed after scoring begins</p>
-                  ` : ''}
+                  ${!this.canChangeTimeSettings
+                    ? html`
+                        <p class="form-help-text text-orange-600">
+                          Timer settings cannot be changed after scoring begins
+                        </p>
+                      `
+                    : ""}
                 </div>
-                ${this.isTimedGame ? html`
-                  <!-- Time Limit Fields -->
-                  <div class="form-group">
-                    <label class="form-label">Time Limit</label>
-                    <div class="flex gap-2">
-                      <div class="flex-1">
-                        <input
-                          type="number"
-                          id="hours-lg"
-                          name="hours"
-                          min="0"
-                          step="1"
-                          class="form-input"
-                          placeholder="Hours"
-                          ?disabled=${!this.canChangeTimeSettings}
-                          .value=${this.hours > 0 ? String(this.hours) : ""}
-                          @input="${this.handleHoursInput}" />
+                ${this.isTimedGame
+                  ? html`
+                      <!-- Time Limit Fields -->
+                      <div class="form-group">
+                        <label class="form-label">Time Limit</label>
+                        <div class="flex gap-2">
+                          <div class="flex-1">
+                            <input
+                              type="number"
+                              id="hours-lg"
+                              name="hours"
+                              min="0"
+                              step="1"
+                              class="form-input"
+                              placeholder="Hours"
+                              ?disabled=${!this.canChangeTimeSettings}
+                              .value=${this.hours > 0 ? String(this.hours) : ""}
+                              @input="${this.handleHoursInput}" />
+                          </div>
+                          <div class="flex-1">
+                            <input
+                              type="number"
+                              id="minutes-lg"
+                              name="minutes"
+                              min="0"
+                              max="59"
+                              step="1"
+                              class="form-input"
+                              placeholder="Minutes"
+                              ?disabled=${!this.canChangeTimeSettings}
+                              .value=${this.minutes > 0 ? String(this.minutes) : ""}
+                              @input="${this.handleMinutesInput}" />
+                          </div>
+                        </div>
+                        <p class="form-help-text">Enter at least 1 minute</p>
                       </div>
-                      <div class="flex-1">
-                        <input
-                          type="number"
-                          id="minutes-lg"
-                          name="minutes"
-                          min="0"
-                          max="59"
-                          step="1"
-                          class="form-input"
-                          placeholder="Minutes"
-                          ?disabled=${!this.canChangeTimeSettings}
-                          .value=${this.minutes > 0 ? String(this.minutes) : ""}
-                          @input="${this.handleMinutesInput}" />
-                      </div>
-                    </div>
-                    <p class="form-help-text">Enter at least 1 minute</p>
-                  </div>
-                  ${this.targetScore !== null ? html`
-                    <!-- Timer Behavior Field -->
-                    <div class="form-group">
-                      <label class="form-label">If time expires with no winner</label>
-                      <div class="flex flex-col gap-2">
-                        <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
-                          <input
-                            type="radio"
-                            name="timerBehavior"
-                            value="highest-score"
-                            .checked=${this.timerBehavior === 'highest-score'}
-                            ?disabled=${!this.canChangeTimeSettings}
-                            @change="${this.handleTimerBehaviorChange}"
-                            class="w-4 h-4" />
-                          <span>Highest Score Wins</span>
-                        </label>
-                        <label class="flex items-center gap-2 ${this.canChangeTimeSettings ? 'cursor-pointer' : 'cursor-not-allowed opacity-50'}">
-                          <input
-                            type="radio"
-                            name="timerBehavior"
-                            value="no-winner"
-                            .checked=${this.timerBehavior === 'no-winner'}
-                            ?disabled=${!this.canChangeTimeSettings}
-                            @change="${this.handleTimerBehaviorChange}"
-                            class="w-4 h-4" />
-                          <span>No Winner</span>
-                        </label>
-                      </div>
-                    </div>
-                  ` : ''}
-                ` : ''}
+                      ${this.targetScore !== null
+                        ? html`
+                            <!-- Timer Behavior Field -->
+                            <div class="form-group">
+                              <label class="form-label">If time expires with no winner</label>
+                              <div class="flex flex-col gap-2">
+                                <label
+                                  class="flex items-center gap-2 ${this.canChangeTimeSettings
+                                    ? "cursor-pointer"
+                                    : "cursor-not-allowed opacity-50"}">
+                                  <input
+                                    type="radio"
+                                    name="timerBehavior"
+                                    value="highest-score"
+                                    .checked=${this.timerBehavior === "highest-score"}
+                                    ?disabled=${!this.canChangeTimeSettings}
+                                    @change="${this.handleTimerBehaviorChange}"
+                                    class="w-4 h-4" />
+                                  <span>Highest Score Wins</span>
+                                </label>
+                                <label
+                                  class="flex items-center gap-2 ${this.canChangeTimeSettings
+                                    ? "cursor-pointer"
+                                    : "cursor-not-allowed opacity-50"}">
+                                  <input
+                                    type="radio"
+                                    name="timerBehavior"
+                                    value="no-winner"
+                                    .checked=${this.timerBehavior === "no-winner"}
+                                    ?disabled=${!this.canChangeTimeSettings}
+                                    @change="${this.handleTimerBehaviorChange}"
+                                    class="w-4 h-4" />
+                                  <span>No Winner</span>
+                                </label>
+                              </div>
+                            </div>
+                          `
+                        : ""}
+                    `
+                  : ""}
               </div>
 
               <!-- Section C: Player List -->
@@ -668,7 +715,10 @@ export class GameDetailFormComponent extends BaseComponent {
               class="w-full md:w-auto btn btn-secondary">
               Save As Template
             </button>
-            <button ?disabled="${!this.formIsValid}" type="submit" class="w-full md:w-auto btn btn-primary">
+            <button
+              ?disabled="${!this.formIsValid}"
+              type="submit"
+              class="w-full md:w-auto btn btn-primary">
               ${this.isEditMode ? "Update Game" : "Create Game"}
             </button>
           </div>

--- a/src/components/game-detail/form.ts
+++ b/src/components/game-detail/form.ts
@@ -221,9 +221,8 @@ export class GameDetailFormComponent extends BaseComponent {
     }
   }
 
-  private handleTemplateSelect(e: Event) {
-    const select = e.target as HTMLSelectElement;
-    this.selectedTemplateId = select.value;
+  private handleTemplateSelect(e: CustomEvent<{ templateId: string }>) {
+    this.selectedTemplateId = e.detail.templateId;
 
     if (!this.selectedTemplateId) {
       this.resetFormToDefaults();
@@ -379,18 +378,14 @@ export class GameDetailFormComponent extends BaseComponent {
             <!-- Template Selector (create mode only, when templates exist) -->
             ${this.context === "create" && this.templates.length > 0 ? html`
               <div class="form-group pt-md">
-                <label for="template-select" class="form-label">Start from Template</label>
+                <label class="form-label">Start from Template</label>
                 <div class="flex gap-2 items-center">
-                  <select
-                    id="template-select"
-                    class="form-input flex-1"
-                    .value=${this.selectedTemplateId}
-                    @change="${this.handleTemplateSelect}">
-                    <option value="">-- No Template --</option>
-                    ${this.templates.map((t) => html`
-                      <option value="${t.id}">${t.templateName}</option>
-                    `)}
-                  </select>
+                  <x-template-select
+                    class="flex-1"
+                    .templates=${this.templates}
+                    .selectedTemplateId=${this.selectedTemplateId}
+                    @template-select=${this.handleTemplateSelect}>
+                  </x-template-select>
                   ${this.selectedTemplateId ? html`
                     <button
                       type="button"

--- a/src/components/game-detail/player-list.ts
+++ b/src/components/game-detail/player-list.ts
@@ -57,7 +57,7 @@ export class GameDetailPlayerListComponent extends BaseComponent {
                 <span class="w-6 text-sm text-gray-500">${index + 1}.</span>
                 <input
                   type="text"
-                  value="${player}"
+                  .value="${player}"
                   @input="${(e: Event) =>
                     this.updatePlayerName(index, (e.target as HTMLInputElement).value)}"
                   class="flex-1 form-input"

--- a/src/components/game-detail/save-template-modal.ts
+++ b/src/components/game-detail/save-template-modal.ts
@@ -1,0 +1,129 @@
+import { html } from "lit";
+import { customElement, state } from "lit/decorators.js";
+import { createRef, ref, Ref } from "lit/directives/ref.js";
+import { BaseComponent } from "@/utils";
+import { TemplateStorageService } from "@/services";
+
+@customElement("x-save-template-modal")
+export class SaveTemplateModalComponent extends BaseComponent {
+  @state() templateName = "";
+  @state() isDuplicate = false;
+  @state() saveError = false;
+
+  private dialogRef: Ref<HTMLDialogElement> = createRef();
+  private templateStorage = TemplateStorageService.getInstance();
+
+  open(): void {
+    this.templateName = "";
+    this.isDuplicate = false;
+    this.saveError = false;
+    this.updateComplete.then(() => {
+      this.dialogRef.value?.showModal();
+    });
+  }
+
+  close(): void {
+    const dialog = this.dialogRef.value;
+    if (!dialog) return;
+
+    dialog.close();
+
+    const onTransitionEnd = () => {
+      dialog.removeEventListener("transitionend", onTransitionEnd);
+    };
+    dialog.addEventListener("transitionend", onTransitionEnd);
+  }
+
+  private handleInput(e: Event): void {
+    this.templateName = (e.target as HTMLInputElement).value;
+    this.isDuplicate = this.templateName.trim().length > 0 &&
+      this.templateStorage.hasTemplateName(this.templateName.trim());
+    this.saveError = false;
+  }
+
+  private handleSave(): void {
+    if (!this.templateName.trim()) return;
+    this.dispatchEvent(new CustomEvent("save-template", {
+      detail: { templateName: this.templateName.trim() },
+      bubbles: true,
+    }));
+  }
+
+  showSaveError(): void {
+    this.saveError = true;
+  }
+
+  private handleKeyDown = (e: KeyboardEvent): void => {
+    if (e.key === "Escape") {
+      e.preventDefault();
+      this.close();
+    }
+  };
+
+  private handleDialogCancel = (e: Event): void => {
+    e.preventDefault();
+  };
+
+  render() {
+    return html`
+      <dialog
+        ${ref(this.dialogRef)}
+        @cancel=${this.handleDialogCancel}
+        @keydown=${this.handleKeyDown}
+        class="fixed m-0 p-0 border-0 bg-transparent max-w-full max-h-full w-full h-full flex items-center justify-center">
+        <div class="w-[400px] max-sm:w-[95vw] bg-white rounded-xl shadow-2xl flex flex-col max-h-[90vh] border border-gray-200">
+          <div class="flex items-center justify-between p-6 border-b border-gray-200 flex-shrink-0">
+            <h2 class="text-2xl font-bold text-gray-900 m-0">Save As Template</h2>
+            <button
+              type="button"
+              @click=${this.close}
+              class="text-gray-400 hover:text-gray-600 text-3xl font-light leading-none w-8 h-8 flex items-center justify-center transition-colors cursor-pointer bg-transparent border-0 p-0 hover:bg-gray-100 hover:rounded"
+              aria-label="Close">
+              ×
+            </button>
+          </div>
+          <div class="p-6 overflow-y-auto flex-1 text-gray-700">
+            <div class="form-group">
+              <label for="template-name-input" class="form-label">Template Name</label>
+              <input
+                type="text"
+                id="template-name-input"
+                class="form-input"
+                placeholder="e.g. Cribbage, Yahtzee"
+                .value=${this.templateName}
+                @input=${this.handleInput}
+                autocomplete="off" />
+              ${this.isDuplicate ? html`
+                <p class="form-help-text text-orange-600 mt-1">A template with this name already exists.</p>
+              ` : ''}
+              ${this.saveError ? html`
+                <p class="form-help-text text-red-600 mt-1">Failed to save template. Storage may be full.</p>
+              ` : ''}
+            </div>
+            <div class="flex gap-2 justify-end mt-4">
+              <button
+                type="button"
+                @click=${this.close}
+                class="btn btn-secondary">
+                Cancel
+              </button>
+              <button
+                type="button"
+                @click=${this.handleSave}
+                ?disabled=${!this.templateName.trim()}
+                class="btn btn-primary">
+                Save Template
+              </button>
+            </div>
+          </div>
+        </div>
+      </dialog>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "x-save-template-modal": SaveTemplateModalComponent;
+  }
+}

--- a/src/components/game-detail/template-select.ts
+++ b/src/components/game-detail/template-select.ts
@@ -1,0 +1,222 @@
+import { html, nothing } from "lit";
+import { customElement, property, state } from "lit/decorators.js";
+import { classMap } from "lit/directives/class-map.js";
+import { BaseComponent, formatTemplateSummary, type GameTemplate } from "@/utils";
+
+@customElement("x-template-select")
+export class TemplateSelectComponent extends BaseComponent {
+  @property({ type: Array })
+  templates: GameTemplate[] = [];
+
+  @property({ type: String })
+  selectedTemplateId: string = "";
+
+  @state()
+  private isOpen: boolean = false;
+
+  @state()
+  private searchQuery: string = "";
+
+  @state()
+  private highlightedIndex: number = -1;
+
+  private get filteredTemplates(): GameTemplate[] {
+    if (!this.searchQuery) return this.templates;
+    const query = this.searchQuery.toLowerCase();
+    return this.templates.filter((t) => {
+      const name = t.templateName.toLowerCase();
+      const summary = formatTemplateSummary(t).toLowerCase();
+      return name.includes(query) || summary.includes(query);
+    });
+  }
+
+  private get selectedTemplate(): GameTemplate | undefined {
+    return this.templates.find((t) => t.id === this.selectedTemplateId);
+  }
+
+  private boundHandleOutsideClick = this.handleOutsideClick.bind(this);
+
+  connectedCallback() {
+    super.connectedCallback();
+    document.addEventListener("click", this.boundHandleOutsideClick);
+  }
+
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    document.removeEventListener("click", this.boundHandleOutsideClick);
+  }
+
+  private handleOutsideClick(e: MouseEvent) {
+    if (!this.isOpen) return;
+    if (!this.contains(e.target as Node)) {
+      this.close();
+    }
+  }
+
+  private toggle() {
+    if (this.isOpen) {
+      this.close();
+    } else {
+      this.open();
+    }
+  }
+
+  private open() {
+    this.isOpen = true;
+    this.searchQuery = "";
+    this.highlightedIndex = -1;
+    this.updateComplete.then(() => {
+      const input = this.querySelector<HTMLInputElement>(".template-search-input");
+      input?.focus();
+    });
+  }
+
+  private close() {
+    this.isOpen = false;
+    this.searchQuery = "";
+    this.highlightedIndex = -1;
+  }
+
+  private handleSearchInput(e: Event) {
+    const input = e.target as HTMLInputElement;
+    this.searchQuery = input.value;
+    this.highlightedIndex = -1;
+  }
+
+  private handleKeydown(e: KeyboardEvent) {
+    // Total items: "No Template" option (index 0) + filtered templates
+    const totalItems = this.filteredTemplates.length + 1;
+
+    switch (e.key) {
+      case "ArrowDown":
+        e.preventDefault();
+        this.highlightedIndex = (this.highlightedIndex + 1) % totalItems;
+        this.scrollHighlightedIntoView();
+        break;
+      case "ArrowUp":
+        e.preventDefault();
+        this.highlightedIndex = this.highlightedIndex <= 0 ? totalItems - 1 : this.highlightedIndex - 1;
+        this.scrollHighlightedIntoView();
+        break;
+      case "Enter":
+        e.preventDefault();
+        if (this.highlightedIndex >= 0) {
+          if (this.highlightedIndex === 0) {
+            this.selectTemplate("");
+          } else {
+            const template = this.filteredTemplates[this.highlightedIndex - 1];
+            if (template) this.selectTemplate(template.id);
+          }
+        }
+        break;
+      case "Escape":
+        e.preventDefault();
+        this.close();
+        break;
+    }
+  }
+
+  private scrollHighlightedIntoView() {
+    this.updateComplete.then(() => {
+      const highlighted = this.querySelector<HTMLElement>('[data-highlighted="true"]');
+      highlighted?.scrollIntoView({ block: "nearest" });
+    });
+  }
+
+  private selectTemplate(templateId: string) {
+    this.dispatchEvent(
+      new CustomEvent("template-select", {
+        detail: { templateId },
+        bubbles: true,
+        composed: true,
+      })
+    );
+    this.close();
+  }
+
+  render() {
+    const selected = this.selectedTemplate;
+
+    return html`
+      <div class="relative">
+        <button
+          type="button"
+          role="combobox"
+          aria-expanded="${this.isOpen}"
+          aria-haspopup="listbox"
+          aria-controls="template-listbox"
+          class="form-input w-full text-left flex items-center justify-between gap-2"
+          @click="${this.toggle}"
+        >
+          <div class="flex-1 min-w-0">
+            ${selected ? html`
+              <div class="font-semibold truncate">${selected.templateName}</div>
+              <div class="text-sm text-gray-500 truncate">${formatTemplateSummary(selected)}</div>
+            ` : html`
+              <span class="text-gray-400">Search Templates...</span>
+            `}
+          </div>
+          <svg class="w-4 h-4 shrink-0 text-gray-400 transition-transform ${this.isOpen ? "rotate-180" : ""}" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+          </svg>
+        </button>
+
+        ${this.isOpen ? html`
+          <div class="absolute z-50 mt-1 w-full bg-white border border-gray-200 rounded-lg shadow-lg overflow-hidden">
+            <div class="p-2 border-b border-gray-100">
+              <input
+                type="text"
+                class="template-search-input w-full px-3 py-2 text-sm border border-gray-200 rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
+                placeholder="Type to filter..."
+                .value="${this.searchQuery}"
+                @input="${this.handleSearchInput}"
+                @keydown="${this.handleKeydown}"
+              />
+            </div>
+            <ul
+              id="template-listbox"
+              role="listbox"
+              class="max-h-60 overflow-y-auto"
+            >
+              <li
+                role="option"
+                aria-selected="${this.selectedTemplateId === ""}"
+                data-highlighted="${this.highlightedIndex === 0}"
+                class="px-3 py-2 cursor-pointer text-sm text-gray-500 italic hover:bg-gray-50 ${classMap({ "bg-primary/10": this.highlightedIndex === 0 })}"
+                @click="${() => this.selectTemplate("")}"
+              >
+                No Template
+              </li>
+              ${this.filteredTemplates.map((t, i) => {
+                const itemIndex = i + 1;
+                const isHighlighted = this.highlightedIndex === itemIndex;
+                const isSelected = this.selectedTemplateId === t.id;
+                return html`
+                  <li
+                    role="option"
+                    aria-selected="${isSelected}"
+                    data-highlighted="${isHighlighted}"
+                    class="px-3 py-2 cursor-pointer hover:bg-gray-50 ${classMap({ "bg-primary/10": isHighlighted })}"
+                    @click="${() => this.selectTemplate(t.id)}"
+                  >
+                    <div class="font-semibold text-sm">${t.templateName}</div>
+                    <div class="text-xs text-gray-500">${formatTemplateSummary(t)}</div>
+                  </li>
+                `;
+              })}
+              ${this.filteredTemplates.length === 0 && this.searchQuery ? html`
+                <li class="px-3 py-2 text-sm text-gray-400 italic">No matching templates</li>
+              ` : nothing}
+            </ul>
+          </div>
+        ` : nothing}
+      </div>
+    `;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "x-template-select": TemplateSelectComponent;
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import "./components/game/elements/current-score.js";
 import "./components/game-detail/form.js";
 import "./components/game-detail/header.js";
 import "./components/game-detail/player-list.js";
+import "./components/game-detail/save-template-modal.js";
 
 import "./components/games-list.js";
 import "./components/game-list/game.js";

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import "./components/game-detail/form.js";
 import "./components/game-detail/header.js";
 import "./components/game-detail/player-list.js";
 import "./components/game-detail/save-template-modal.js";
+import "./components/game-detail/template-select.js";
 
 import "./components/games-list.js";
 import "./components/game-list/game.js";

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -1,1 +1,2 @@
 export * from './gameStorage.js';
+export * from './templateStorage.js';

--- a/src/services/templateStorage.ts
+++ b/src/services/templateStorage.ts
@@ -1,0 +1,69 @@
+import { LocalStorageAdapter, StorageAdapter, type GameTemplate } from "@/utils";
+
+export interface CreateTemplateOptions {
+  templateName: string;
+  players: string[];
+  targetScore: number | null;
+  timeLimit: number | null;
+  timerBehavior: 'no-winner' | 'highest-score' | null;
+  turnTrackingEnabled: boolean;
+}
+
+export class TemplateStorageService {
+  private storage: StorageAdapter<GameTemplate>;
+  private static instance: TemplateStorageService;
+
+  private constructor() {
+    this.storage = new LocalStorageAdapter<GameTemplate>("scorekeeper-templates");
+  }
+
+  static getInstance(): TemplateStorageService {
+    if (!TemplateStorageService.instance) {
+      TemplateStorageService.instance = new TemplateStorageService();
+    }
+    return TemplateStorageService.instance;
+  }
+
+  createTemplate(options: CreateTemplateOptions): GameTemplate | null {
+    const template: GameTemplate = {
+      id: crypto.randomUUID(),
+      templateName: options.templateName,
+      players: options.players,
+      targetScore: options.targetScore,
+      timeLimit: options.timeLimit,
+      timerBehavior: options.timerBehavior,
+      turnTrackingEnabled: options.turnTrackingEnabled,
+      createdAt: new Date(),
+    };
+
+    const success = this.storage.set(template.id, template);
+    return success ? template : null;
+  }
+
+  getTemplate(id: string): GameTemplate | null {
+    const template = this.storage.get(id);
+    if (!template) return null;
+    return {
+      ...template,
+      createdAt: new Date(template.createdAt),
+    };
+  }
+
+  getAllTemplates(): GameTemplate[] {
+    return this.storage.keys()
+      .map((id) => this.getTemplate(id))
+      .filter((t): t is GameTemplate => t !== null)
+      .sort((a, b) => a.createdAt.getTime() - b.createdAt.getTime());
+  }
+
+  deleteTemplate(id: string): boolean {
+    return this.storage.remove(id);
+  }
+
+  hasTemplateName(name: string): boolean {
+    const normalized = name.trim().toLowerCase();
+    return this.getAllTemplates().some(
+      (t) => t.templateName.toLowerCase() === normalized
+    );
+  }
+}

--- a/src/styles/utilities/forms.css
+++ b/src/styles/utilities/forms.css
@@ -8,18 +8,26 @@
   }
 
   .form-input {
-    @apply block w-full border text-base border-gray-300 rounded-md shadow-sm px-3 py-2 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary;
+    @apply flex w-full border text-base border-gray-300 rounded-md shadow-sm px-3 py-2 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-primary focus:border-primary;
   }
 
   .form-input:disabled {
     @apply bg-gray-100 cursor-not-allowed;
   }
 
+  select.form-input {
+    @apply appearance-none bg-white pr-8;
+    background-image: url("data:image/svg+xml;charset=UTF-8,%3csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24' fill='none' stroke='currentColor' stroke-width='2' stroke-linecap='round' stroke-linejoin='round'%3e%3cpolyline points='6 9 12 15 18 9'%3e%3c/polyline%3e%3c/svg%3e");
+    background-repeat: no-repeat;
+    background-position: right 0.5rem center;
+    background-size: 1.5em 1.5em;
+  }
+
   .form-help-text {
     @apply text-xs text-gray-500;
   }
 
-  .form-input  + .form-help-text {
+  .form-input + .form-help-text {
     @apply mt-sm;
   }
 }

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,5 +1,16 @@
 export type ScoreEntry = [number, number];
 
+export interface GameTemplate {
+  id: string;
+  templateName: string;
+  players: string[];
+  targetScore: number | null;
+  timeLimit: number | null;
+  timerBehavior: 'no-winner' | 'highest-score' | null;
+  turnTrackingEnabled: boolean;
+  createdAt: Date;
+}
+
 export interface GamePlayer {
   index: number;
   name: string;

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -2,6 +2,7 @@ export * from "./base-component.js";
 export * from "./storage-adapters/index.js";
 export * from "./safe-call.js";
 export * from "./time.js";
+export * from "./template-summary.js";
 
 // Re-export types from other modules
 export * from "../types/index.js";

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,6 +1,7 @@
 export * from "./base-component.js";
 export * from "./storage-adapters/index.js";
 export * from "./safe-call.js";
+export * from "./time.js";
 
 // Re-export types from other modules
 export * from "../types/index.js";

--- a/src/utils/template-summary.ts
+++ b/src/utils/template-summary.ts
@@ -13,11 +13,16 @@ export function formatTemplateSummary(template: GameTemplate): string {
     const timeParts: string[] = [];
     if (hours > 0) timeParts.push(`${hours}h`);
     if (minutes > 0) timeParts.push(`${minutes}m`);
-    const behavior = template.timerBehavior === "highest-score"
-      ? "highest score wins"
-      : "no winner";
-    parts.push(`Timed Game: ${timeParts.join(" ")}, ${behavior}`);
+    let timedStr = `Timed: ${timeParts.join(" ")}`;
+    if (template.timerBehavior !== null) {
+      timedStr += template.timerBehavior === "highest-score"
+        ? ", highest score wins"
+        : ", no winner";
+    }
+    parts.push(timedStr);
   }
+
+  parts.push(template.turnTrackingEnabled ? "Turn-based" : "Open Scoring");
 
   if (template.players.length > 0) {
     const maxDisplay = 3;

--- a/src/utils/template-summary.ts
+++ b/src/utils/template-summary.ts
@@ -1,0 +1,34 @@
+import { parseTimeLimit } from "./time.js";
+import type { GameTemplate } from "../types/index.js";
+
+export function formatTemplateSummary(template: GameTemplate): string {
+  const parts: string[] = [];
+
+  if (template.targetScore !== null) {
+    parts.push(`Target Score: ${template.targetScore}`);
+  }
+
+  if (template.timeLimit !== null && template.timeLimit > 0) {
+    const { hours, minutes } = parseTimeLimit(template.timeLimit);
+    const timeParts: string[] = [];
+    if (hours > 0) timeParts.push(`${hours}h`);
+    if (minutes > 0) timeParts.push(`${minutes}m`);
+    const behavior = template.timerBehavior === "highest-score"
+      ? "highest score wins"
+      : "no winner";
+    parts.push(`Timed Game: ${timeParts.join(" ")}, ${behavior}`);
+  }
+
+  if (template.players.length > 0) {
+    const maxDisplay = 3;
+    const displayed = template.players.slice(0, maxDisplay);
+    const remaining = template.players.length - maxDisplay;
+    let playerStr = `${template.players.length} Player${template.players.length !== 1 ? "s" : ""}: ${displayed.join(", ")}`;
+    if (remaining > 0) {
+      playerStr += ` + ${remaining} more`;
+    }
+    parts.push(playerStr);
+  }
+
+  return parts.join(" \u2022 ");
+}

--- a/src/utils/time.ts
+++ b/src/utils/time.ts
@@ -1,0 +1,4 @@
+export function parseTimeLimit(totalSeconds: number): { hours: number; minutes: number } {
+  const totalMinutes = Math.floor(totalSeconds / 60);
+  return { hours: Math.floor(totalMinutes / 60), minutes: totalMinutes % 60 };
+}


### PR DESCRIPTION
## Summary

- Add game template system allowing users to save and reuse game configurations (players, target score, time settings, turn tracking)
- Replace native `<select>` with a rich, searchable dropdown component (`x-template-select`) featuring type-to-filter, keyboard navigation, and two-line items showing template name and configuration summary
- Move game name field above the template selector and add an OR divider to separate template selection from manual configuration

## Test plan

- [x] Navigate to New Game page and verify the template selector appears when templates exist
- [x] Verify typing in the search input filters templates by name and summary
- [x] Verify selecting a template populates all form fields (players, target score, time settings, turn tracking)
- [x] Verify selecting "No Template" resets the form to defaults
- [x] Verify keyboard navigation works (Arrow keys, Enter, Escape)
- [x] Verify clicking outside the dropdown closes it
- [x] Verify the Delete button removes a selected template
- [x] Verify saving a new template from the form footer works
- [x] Verify the OR divider displays correctly between the template selector and form options
- [x] Verify edit mode does not show the template selector