### PR TITLE
Fix Firebase static import crash and update deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "18"
+          node-version: "20"
           cache: "npm"
 
       - name: Install dependencies
@@ -30,6 +30,13 @@ jobs:
 
       - name: Build application
         run: npm run build
+        env:
+          VITE_FIREBASE_API_KEY: ${{ secrets.VITE_FIREBASE_API_KEY }}
+          VITE_FIREBASE_AUTH_DOMAIN: ${{ secrets.VITE_FIREBASE_AUTH_DOMAIN }}
+          VITE_FIREBASE_PROJECT_ID: ${{ secrets.VITE_FIREBASE_PROJECT_ID }}
+          VITE_FIREBASE_STORAGE_BUCKET: ${{ secrets.VITE_FIREBASE_STORAGE_BUCKET }}
+          VITE_FIREBASE_MESSAGING_SENDER_ID: ${{ secrets.VITE_FIREBASE_MESSAGING_SENDER_ID }}
+          VITE_FIREBASE_APP_ID: ${{ secrets.VITE_FIREBASE_APP_ID }}
 
       - name: Deploy to server
         uses: appleboy/ssh-action@v1.0.3

--- a/src/components/auth/auth-controls.ts
+++ b/src/components/auth/auth-controls.ts
@@ -1,4 +1,4 @@
-import { html, nothing, TemplateResult } from "lit";
+import { html, nothing } from "lit";
 import { customElement, state } from "lit/decorators.js";
 import { createRef, ref, Ref } from "lit/directives/ref.js";
 import { BaseComponent } from "@/utils";

--- a/src/services/firebase.ts
+++ b/src/services/firebase.ts
@@ -76,14 +76,14 @@ export async function signOut(): Promise<void> {
 export async function activateSync(userId: string): Promise<void> {
   // Games
   const localGames = new LocalStorageAdapter<StoredGame>("scorekeeper");
-  const firestoreGames = new FirestoreStorageAdapter<StoredGame>("games", userId);
+  const firestoreGames = new FirestoreStorageAdapter<StoredGame>(db, "games", userId);
   const throttledGames = new ThrottledStorageAdapter(firestoreGames, 30_000);
   activeThrottledAdapter = throttledGames;
   GameStorageService.initialize(new SyncedStorageAdapter(localGames, throttledGames));
 
   // Templates
   const localTemplates = new LocalStorageAdapter<GameTemplate>("scorekeeper-templates");
-  const firestoreTemplates = new FirestoreStorageAdapter<GameTemplate>("templates", userId);
+  const firestoreTemplates = new FirestoreStorageAdapter<GameTemplate>(db, "templates", userId);
   const throttledTemplates = new ThrottledStorageAdapter(firestoreTemplates, 30_000);
   activeTemplateThrottledAdapter = throttledTemplates;
   TemplateStorageService.initialize(new SyncedStorageAdapter(localTemplates, throttledTemplates));

--- a/src/utils/storage-adapters/firestore-storage.ts
+++ b/src/utils/storage-adapters/firestore-storage.ts
@@ -10,17 +10,19 @@ import {
   writeBatch,
   CollectionReference,
   DocumentData,
+  Firestore,
   Timestamp,
 } from "firebase/firestore";
-import { db } from "@/services/firebase.js";
 import type { StorageAdapter } from "./types.js";
 import type { ScoreEntry } from "@/types/index.js";
 
 export class FirestoreStorageAdapter<T extends object> implements StorageAdapter<T> {
   private collectionRef: CollectionReference;
+  private db: Firestore;
   private userId: string;
 
-  constructor(collectionName: string, userId: string) {
+  constructor(db: Firestore, collectionName: string, userId: string) {
+    this.db = db;
     this.collectionRef = collection(db, collectionName);
     this.userId = userId;
   }
@@ -59,7 +61,7 @@ export class FirestoreStorageAdapter<T extends object> implements StorageAdapter
     const q = query(this.collectionRef, where("userId", "==", this.userId));
     const snapshot = await getDocs(q);
     for (let i = 0; i < snapshot.docs.length; i += 500) {
-      const batch = writeBatch(db);
+      const batch = writeBatch(this.db);
       snapshot.docs.slice(i, i + 500).forEach(d => batch.delete(d.ref));
       await batch.commit();
     }


### PR DESCRIPTION
## Summary

- Remove static import of `firebase.ts` from `FirestoreStorageAdapter` — it was being pulled in transitively via `@/utils`, causing Firebase to initialize at startup even when no API key was configured, which crashed the app and broke unrelated features like the New Game form
- Pass `db` as a constructor argument to `FirestoreStorageAdapter` instead
- Bump Node.js to 20 in the deploy workflow
- Pass `VITE_FIREBASE_*` secrets as env vars during the build step so Firebase is configured in production bundles

## Test plan

- [x] App works normally with no `.env` file (local-only mode, no console errors)
- [x] New Game form works without Firebase configured
- [ ] Firebase sync still works when `.env` is present and credentials are valid
- [ ] Deploy workflow builds successfully with secrets configured in GitHub