### PR TITLE
Improve header layout for mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -19,14 +19,14 @@
         <div class="h-full flex flex-col">
           <header class="flex gap-md p-md pt-safe-area-top border-b-2 bg-gray-light flex-shrink-0">
             <!-- Title and subtitle -->
-            <div class="flex-1">
+            <div class="flex-1 min-w-0">
               <h1 class="text-3xl font-semibold text-gray-900 mb-1">Scorekeeper</h1>
               <p class="text-gray-600">Select a game to start playing, or make a new game.</p>
             </div>
 
-            <!-- Actions (top-right corner) -->
-            <div class="self-start flex items-center gap-2">
-              <a href="/pages/new.html" class="btn-sm btn-primary"> New Game </a>
+            <!-- Actions -->
+            <div class="flex flex-col sm:flex-row items-end sm:items-center gap-2 shrink-0">
+              <a href="/pages/new.html" class="btn btn-primary sm:order-last"> New Game </a>
               <x-auth-controls></x-auth-controls>
             </div>
           </header>


### PR DESCRIPTION
## Summary

- Stack New Game and auth controls vertically on screens narrower than 640px, right-aligned, with New Game on top
- At the sm breakpoint they sit in a single row with New Game to the right of the auth controls
- Upgrades the New Game button from `btn-sm` to `btn`